### PR TITLE
[#184384065] Remove space in the bottom of the titles

### DIFF
--- a/stories/example-generalized-list.stories.js
+++ b/stories/example-generalized-list.stories.js
@@ -22,16 +22,16 @@ const listHTML = `
             <div class="d-flex py-3 align-items-center ps-4 pe-2 gap-2 pe-lg-4">
               <div class="minw-0">
                 <div class="position-relative">
-                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                    <div class="flex-grow-1 text-truncate h3">
+                  <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                    <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
                     </div>
                     <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                   </h4>
-                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                    <div class="flex-grow-1 text-truncate h4">
+                  <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                    <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
@@ -159,16 +159,16 @@ const listHTML = `
 
               <div class="minw-0">
                 <div class="position-relative">
-                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                    <div class="flex-grow-1 text-truncate h3">
+                  <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                    <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
                     </div>
                     <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                   </h4>
-                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                    <div class="flex-grow-1 text-truncate h4">
+                  <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                    <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
@@ -318,16 +318,16 @@ const listHTML = `
 
               <div class="minw-0">
                 <div class="position-relative">
-                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                    <div class="flex-grow-1 text-truncate h3">
+                  <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                    <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
                     </div>
                     <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                   </h4>
-                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                    <div class="flex-grow-1 text-truncate h4">
+                  <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                    <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
@@ -469,16 +469,16 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                        <div class="flex-grow-1 text-truncate h3">
+                      <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                        <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                           <a href="#" class="stretched-link">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
                         </div>
                         <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                       </h4>
-                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                        <div class="flex-grow-1 text-truncate h4">
+                      <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                        <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                           <a href="#" class="stretched-link">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
@@ -622,17 +622,17 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                        <div class="flex-grow-1 text-truncate h3">
-                          <a href="#" class="stretched-link">
+                      <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                        <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
+                          <a href="#" class="stretched-link lh-1">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
                         </div>
                         <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                       </h4>
-                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                        <div class="flex-grow-1 text-truncate h4">
-                          <a href="#" class="stretched-link">
+                      <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                        <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
+                          <a href="#" class="stretched-link lh-1">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
                         </div>
@@ -774,16 +774,16 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                        <div class="flex-grow-1 text-truncate h3">
+                      <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                        <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                           <a href="#" class="stretched-link">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
                         </div>
                         <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                       </h4>
-                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                        <div class="flex-grow-1 text-truncate h4">
+                      <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                        <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                           <a href="#" class="stretched-link">
                             Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                           </a>
@@ -917,16 +917,16 @@ const listHTML = `
             <div class="d-flex py-3 align-items-center px-12 gap-2 pe-lg-4">
               <div class="minw-0">
                 <div class="position-relative">
-                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                    <div class="flex-grow-1 text-truncate h3">
+                  <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                    <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>
                     </div>
                     <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                   </h4>
-                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                    <div class="flex-grow-1 text-truncate h4">
+                  <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                    <div class="flex-grow-1 text-truncate h4 lh-sm m-0">
                       <a href="#" class="stretched-link">
                         Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
                       </a>

--- a/stories/example-generalized-list.stories.js
+++ b/stories/example-generalized-list.stories.js
@@ -11,26 +11,33 @@ const listHTML = `
     <ul class="list-unstyled">
       <li class="">
         <div class="group focus-within ms-4 ms-lg-0 mb-3">
-
           <div class="card border-lg-primary position-relative transition-all">
             <div class="group-hover-lg-opacity group-hover-mt-0 transition-all drag-handle ms-n9 d-flex position-absolute -ml-2 mt-0 mt-lg-1 h-100 pe-2">
               <button type="button" title="Drag to Position" aria-title="Drag to Position" tabindex="-1" class="btn p-2 d-flex align-items-center justify-content-center">
-
                 <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-grid-dots" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.5" stroke="#000000" fill="none" stroke-linecap="round" stroke-linejoin="round">
                   <use xlink:href="${iconSprite}#tabler-grid-dots" />
                 </svg>
               </button>
             </div>
-
             <div class="d-flex py-3 align-items-center ps-4 pe-2 gap-2 pe-lg-4">
-
               <div class="minw-0">
                 <div class="position-relative">
-                  <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                    <div class="flex-grow-1 text-truncate"><a href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                    <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                  </h3>
+                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                    <div class="flex-grow-1 text-truncate h3">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h4>
+                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                    <div class="flex-grow-1 text-truncate h4">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h5>
                   <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                   <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                     <div class="d-flex gap-1">
@@ -152,11 +159,22 @@ const listHTML = `
 
               <div class="minw-0">
                 <div class="position-relative">
-                  <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                    <div class="flex-grow-1 text-truncate"><a href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                    <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                  </h3>
+                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                    <div class="flex-grow-1 text-truncate h3">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h4>
+                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                    <div class="flex-grow-1 text-truncate h4">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h5>
                   <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                   <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                     <div class="d-flex gap-1">
@@ -300,11 +318,22 @@ const listHTML = `
 
               <div class="minw-0">
                 <div class="position-relative">
-                  <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                    <div class="flex-grow-1 text-truncate"><a href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                    <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                  </h3>
+                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                    <div class="flex-grow-1 text-truncate h3">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h4>
+                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                    <div class="flex-grow-1 text-truncate h4">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h5>
                   <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                   <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                     <div class="d-flex gap-1">
@@ -440,11 +469,22 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                        <div class="flex-grow-1 text-truncate"><a role="treeitem" href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                        <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                      </h3>
+                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                        <div class="flex-grow-1 text-truncate h3">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h4>
+                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                        <div class="flex-grow-1 text-truncate h4">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h5>
                       <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                       <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                         <div class="d-flex gap-1">
@@ -582,11 +622,22 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                        <div class="flex-grow-1 text-truncate"><a role="treeitem" href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                        <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                      </h3>
+                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                        <div class="flex-grow-1 text-truncate h3">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h4>
+                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                        <div class="flex-grow-1 text-truncate h4">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h5>
                       <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                       <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                         <div class="d-flex gap-1">
@@ -723,11 +774,22 @@ const listHTML = `
 
                   <div class="minw-0">
                     <div class="position-relative">
-                      <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                        <div class="flex-grow-1 text-truncate"><a role="treeitem" href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                        <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                      </h3>
+                      <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                        <div class="flex-grow-1 text-truncate h3">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h4>
+                      <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                        <div class="flex-grow-1 text-truncate h4">
+                          <a href="#" class="stretched-link">
+                            Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                          </a>
+                        </div>
+                        <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                      </h5>
                       <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                       <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                         <div class="d-flex gap-1">
@@ -855,11 +917,22 @@ const listHTML = `
             <div class="d-flex py-3 align-items-center px-12 gap-2 pe-lg-4">
               <div class="minw-0">
                 <div class="position-relative">
-                  <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                    <div class="flex-grow-1 text-truncate"><a role="treeitem" href="#" class="stretched-link">Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</a></div>
-                    <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-
-                  </h3>
+                  <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                    <div class="flex-grow-1 text-truncate h3">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h4>
+                  <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                    <div class="flex-grow-1 text-truncate h4">
+                      <a href="#" class="stretched-link">
+                        Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Proin eget tortor risus. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Quisque velit nisi, pretium ut lacinia in, elementum id enim.
+                      </a>
+                    </div>
+                    <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                  </h5>
                   <p class="m-0 text-truncate minw-0">Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a.</p>
                   <dl class="d-flex flex-wrap flex-column flex-lg-row gap-0 gap-lg-4 m-0">
                     <div class="d-flex gap-1">

--- a/stories/generalized-list-item.stories.js
+++ b/stories/generalized-list-item.stories.js
@@ -41,14 +41,22 @@ const listContent = (type) => {
             </div>
             <div class="minw-0">
               <div class="position-relative">
-                <h3 class="d-flex align-items-center m-0 mb-1 fs-6 fs-lg-5 gap-2">
-                  <div class="flex-grow-1 text-truncate">
+                <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
+                  <div class="flex-grow-1 text-truncate h3">
                     <a href="#" class="stretched-link">
                       ${type.name}
                     </a>
                   </div>
-                  <span class="badge bg-secondary flex-shrink-0 fs-7 fs-lg-6">Some Label</span>
-                </h3>
+                  <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                </h4>
+                <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
+                  <div class="flex-grow-1 text-truncate h4">
+                    <a href="#" class="stretched-link">
+                      ${type.name}
+                    </a>
+                  </div>
+                  <span class="badge bg-secondary flex-shrink-0">Some Label</span>
+                </h5>
                 <p class="m-0 text-truncate minw-0">
                   ${type.description}
                 </p>

--- a/stories/generalized-list-item.stories.js
+++ b/stories/generalized-list-item.stories.js
@@ -41,17 +41,17 @@ const listContent = (type) => {
             </div>
             <div class="minw-0">
               <div class="position-relative">
-                <h4 class="d-none d-md-flex align-items-center m-0 mb-1 gap-2 ">
-                  <div class="flex-grow-1 text-truncate h3">
-                    <a href="#" class="stretched-link">
+                <h4 class="d-none d-md-flex align-items-center m-0 gap-2 lh-sm">
+                  <div class="flex-grow-1 text-truncate h3 mb-0 lh-sm">
+                    <a href="#" class="stretched-link lh-1">
                       ${type.name}
                     </a>
                   </div>
                   <span class="badge bg-secondary flex-shrink-0">Some Label</span>
                 </h4>
-                <h5 class="d-flex d-md-none align-items-center m-0 mb-1 gap-2">
-                  <div class="flex-grow-1 text-truncate h4">
-                    <a href="#" class="stretched-link">
+                <h5 class="d-flex d-md-none align-items-center m-0 gap-2">
+                  <div class="flex-grow-1 text-truncate mb-0 lh-sm">
+                    <a href="#" class="stretched-link lh-1">
                       ${type.name}
                     </a>
                   </div>


### PR DESCRIPTION
> [Generalized list small fix](https://www.pivotaltracker.com/n/projects/2198983/stories/184384065/comments/235491615): remove space in the bottom of the titles.
> 
> [Testbox Storybook](https://zvedovatto.janus-storybook.74dev.symplicity.com/?path=/story/examples-lists--generalized-list)

> Before:
> ![Screen Shot 2023-02-14 at 11 14 19](https://user-images.githubusercontent.com/86245217/218763713-8a9fbc95-7910-4dfc-8e4a-470b208b61e1.png)
> 
> After:
> ![Screen Shot 2023-02-14 at 11 13 38](https://user-images.githubusercontent.com/86245217/218763521-056a5c6e-16ec-4934-a7cb-348424c79f5c.png)
> 
